### PR TITLE
Sort plugins alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ A curated list of Budibase datasources and APIs contributed by the community.
 
 Title | Description | Type | Author | Tags |
 |---|---|---|---|--|
-| [n8n workflows](https://github.com/melohagan/budibase-datasource-n8n-workflow) | CRUD operations for n8n workflows  | API | [Mel O'Hagan](https://github.com/melohagan/) | `workflow` `automation`  |
-| [SurrealDB](https://github.com/melohagan/budibase-datasource-surrealdb) | Connector for SurrealDB | Relational | [Mel O'Hagan](https://github.com/melohagan/) | `NoSQL` `SurrealQL` |
-| [Stripe subscriptions](https://github.com/melohagan/budibase-datasource-stripe-subscriptions) | Manage subscriptions, subscription items and subscription schedules | API | [Mel O'Hagan](https://github.com/melohagan/) | `payments` |
-| [Stripe checkout](https://github.com/melohagan/budibase-datasource-stripe-checkout) | Manage checkout sessions | API | [Mel O'Hagan](https://github.com/melohagan/) | `payments` |
-| [Supabase](https://github.com/melohagan/budibase-datasource-supabase) | Connector for Supabase | Relational | [Mel O'Hagan](https://github.com/melohagan/) | `postgres` |
-| [Github Issues](https://github.com/doingandlearning/bb-github-plugin) | Connector for Github Issues API | Datasource | [Kevin Cunningham](https://twitter.com/dolearning) | `tag` |
 | [Big Query](https://github.com/marblekirby/budibase-big-query-plugin) | Connector for Google Big Query Datawarehouse | Datasource | [Daniel Loudon](https://github.com/marblekirby) | `GCP` |
+| [Github Issues](https://github.com/doingandlearning/bb-github-plugin) | Connector for Github Issues API | Datasource | [Kevin Cunningham](https://twitter.com/dolearning) | `tag` |
+| [n8n workflows](https://github.com/melohagan/budibase-datasource-n8n-workflow) | CRUD operations for n8n workflows  | API | [Mel O'Hagan](https://github.com/melohagan/) | `workflow` `automation`  |
+| [Stripe checkout](https://github.com/melohagan/budibase-datasource-stripe-checkout) | Manage checkout sessions | API | [Mel O'Hagan](https://github.com/melohagan/) | `payments` |
+| [Stripe subscriptions](https://github.com/melohagan/budibase-datasource-stripe-subscriptions) | Manage subscriptions, subscription items and subscription schedules | API | [Mel O'Hagan](https://github.com/melohagan/) | `payments` |
+| [Supabase](https://github.com/melohagan/budibase-datasource-supabase) | Connector for Supabase | Relational | [Mel O'Hagan](https://github.com/melohagan/) | `postgres` |
+| [SurrealDB](https://github.com/melohagan/budibase-datasource-surrealdb) | Connector for SurrealDB | Relational | [Mel O'Hagan](https://github.com/melohagan/) | `NoSQL` `SurrealQL` |
 
 <br />
 
@@ -55,24 +55,24 @@ A curated list of Budibase components contributed by the community.
 
 Title | Description | Type | Author | Tags |
 |---|---|---|---|---|
+| [Accordion](https://github.com/andz-bb/budibase-component-accordion) | Simple accordion collapsible container | Component | [Andrew Thompson](https://github.com/andz-bb) | `layout` `container` `accordion` |
 | [Archery Score Tracker](https://github.com/Rory-Powell/budibase-archery-component-plugin) | Track archery scores with an interactive target canvas | Component | [Rory Powell](https://github.com/Rory-Powell) | `archery` `canvas` |
 | [Avatar](https://github.com/doingandlearning/bb-avatar-component-plugin) | A content area for a profile picture and details | Component  | [Kevin Cunningham](https://twitter.com/dolearning) | `display` `profile` `image` |
+| [Budibase QR Code Scanner](https://github.com/chungchunwang/Budibase-QR-Code-Scanner)| A Budibase form component that scans QR codes. | Component | [Chungchun Wang](https://github.com/chungchunwang) | `qr-code` `scanner` `form` |
+| [Code Block](https://github.com/rosnerdev/bb-code-block) | Display your code in budibase no matter what language your code is written in | Component | [Yahav Rosner](https://github.com/rosnerdev) | `code` `highlightjs` `dark mode` |
 | [Comment Box](https://github.com/aptkingston/budibase-comment-box) | Quickly add comments to your data | Component | [Andrew Kingston](https://github.com/aptkingston) | `comment` `chat` |
 | [Countup](https://github.com/melohagan/budibase-component-countup) | Heading that counts up from an initial number to a target number | Heading | [Pouya Saadeghi](https://github.com/saadeghi) | `heading` `animated` |
 | [Discord Widget](https://github.com/YuanZhang98/budibase-discord) | Discord widget that displays online users and invites | Component | [Yuan Zhang](https://github.com/YuanZhang98) | `chat` `discord` `widget` |
+| [Equation](https://github.com/rosnerdev/budibase-equation) | Display math equations using the LaTeX syntax in budibase | Component | [Yahav Rosner](https://github.com/rosnerdev) | `latex` `math` `equation` |
 | [Fancy Password Input](https://github.com/doggodoge/fancy-password-input) | Nice password input field with complexity progress bar | Component | [Gary Moore](https://github.com/doggodoge) | `input` `password` `forms` |
 | [Google Drive Embed](https://github.com/YuanZhang98/budibase-google-drive-embed) | Widget to display shared google drive files and folders | Component | [Yuan Zhang](https://github.com/YuanZhang98) | `drive` `google` `widget` |
 | [Gradient header](https://github.com/joebudi/budibase-component-gradient-header) | The gradient header sits on top of your screens and makes them look  prettier | Header component | [Joe Johnston](https://github.com/joebudi) | `image` `gradient` `emoji` |
 | [Kasper date-picker with Locale setting!](https://github.com/melohagan/budibase-component-kasper-date-picker) | Date picker form input that allows you to set the locale | Form Input | [Mel O'Hagan](https://github.com/melohagan/) | `form` `input` `date` `picker` | 
 | [Microphone](https://github.com/shogunpurple/budibase-component-microphone) | Microphone voice recorder with download support | Component | [Martin McKeaveney](https://github.com/shogunpurple) | `files` `audio` |
 | [Number Spinner](https://github.com/melohagan/budibase-component-number-spinner) | Number field that can be set with the mouse drag | Form Input | [Hartmut Bohnacker](https://github.com/bohnacker) | `number` `spinner` |
-| [Accordion](https://github.com/andz-bb/budibase-component-accordion) | Simple accordion collapsible container | Component | [Andrew Thompson](https://github.com/andz-bb) | `layout` `container` `accordion` |
-| [Star Rating](https://github.com/andz-bb/budibase-component-star-rating) | Number input with star/heart UI | Form Input | [Andrew Thompson](https://github.com/andz-bb) | `form` `input` |
 | [QR Code](https://github.com/rosnerdev/bb-qr-code) | Display your data as a qr code in budibase | Component | [Yahav Rosner](https://github.com/rosnerdev) | `qr-code` `image` |
-| [Toggle button](https://github.com/YuanZhang98/budibase-toggle) | Toggle button with customizable colors | Component | [Yuan Zhang](https://github.com/YuanZhang98) | `toggle` `color` `input` |
-| [Equation](https://github.com/rosnerdev/budibase-equation) | Display math equations using the LaTeX syntax in budibase | Component | [Yahav Rosner](https://github.com/rosnerdev) | `latex` `math` `equation` |
-| [Code Block](https://github.com/rosnerdev/bb-code-block) | Display your code in budibase no matter what language your code is written in | Component | [Yahav Rosner](https://github.com/rosnerdev) | `code` `highlightjs` `dark mode` |
 | [Spotify Embed](https://github.com/YuanZhang98/budibase-spotify-playlist) | Spotify playlist chooser with embedded UI | Component | [Yuan Zhang](https://github.com/YuanZhang98) | `audio` `spotify` `music` |
-| [Budibase QR Code Scanner](https://github.com/chungchunwang/Budibase-QR-Code-Scanner)| A Budibase form component that scans QR codes. | Component | [Chungchun Wang](https://github.com/chungchunwang) | `qr-code` `scanner` `form` |
-| [Youtube Embed](https://github.com/YuanZhang98/budibase-youtube-embed) | Embedded youtube video player with playlist support | Component | [Yuan Zhang](https://github.com/YuanZhang98) | `youtube` `video` `player` |
 | [Spotify Embeder](https://github.com/NoelJacob/bb-spotify-embed) | Spotify Embed plugin provides an embeddable view of a track, artist, album, user, playlist, podcast, or episode for use within your web project. | Component | [Noel Jacob](https://github.com/NoelJacob/) | `audio` `spotify` `music` `embed` |
+| [Star Rating](https://github.com/andz-bb/budibase-component-star-rating) | Number input with star/heart UI | Form Input | [Andrew Thompson](https://github.com/andz-bb) | `form` `input` |
+| [Toggle button](https://github.com/YuanZhang98/budibase-toggle) | Toggle button with customizable colors | Component | [Yuan Zhang](https://github.com/YuanZhang98) | `toggle` `color` `input` |
+| [Youtube Embed](https://github.com/YuanZhang98/budibase-youtube-embed) | Embedded youtube video player with playlist support | Component | [Yuan Zhang](https://github.com/YuanZhang98) | `youtube` `video` `player` |


### PR DESCRIPTION
This simply helps display the API/Data Sources and Plugins list alphabetically for easier viewing. I wish I had the skills to create my own plugins, so this is what I can contribute.

Signed-off-by: Dave Conroy <23528985+tiredofit@users.noreply.github.com>