### PR TITLE
Atlassian Jira Cloud issues datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Title | Description | Type | Author | Tags |
 | [Appwrite teams](https://github.com/melohagan/budibase-datasource-appwrite-teams) | Connector for managing Appwrite teams | Datasource | [Mel O'Hagan](https://github.com/melohagan/) | `Appwrite` `BaaS` |
 | [Big Query](https://github.com/marblekirby/budibase-big-query-plugin) | Connector for Google Big Query Datawarehouse | Datasource | [Daniel Loudon](https://github.com/marblekirby) | `GCP` |
 | [Github Issues](https://github.com/doingandlearning/bb-github-plugin) | Connector for Github Issues API | Datasource | [Kevin Cunningham](https://twitter.com/dolearning) | `tag` |
+| [Jira Cloud Issues](https://github.com/darrenmoura/budibase-datasource-jira-cloud-issues) | Connector for Jira Cloud Issues API | Datasource | [Darren Moura McGarry](https://github.com/darrenmoura/) | `Jira` `Atlassian` `Issues` |
 | [n8n workflows](https://github.com/melohagan/budibase-datasource-n8n-workflow) | CRUD operations for n8n workflows  | API | [Mel O'Hagan](https://github.com/melohagan/) | `workflow` `automation`  |
 | [Stripe balance + charges](https://github.com/melohagan/budibase-datasource-stripe-balance-charges) | Manage Stripe Balances, Balance Transactions and Charges | API | [Mel O'Hagan](https://github.com/melohagan/) | `payments` |
 | [Stripe bank account, cash balance, card](https://github.com/melohagan/budibase-datasource-stripe-bank-account-card-cash) | Manage Stripe bank accounts, cash balance and cards | API | [Mel O'Hagan](https://github.com/melohagan/) | `payments` |


### PR DESCRIPTION
A connector for Atlassian's Jira Cloud specifically targetting issues. Can do the usual CrUD as well as assign/unassign an issue and search for issues by JQL. Repo can be found [here](https://github.com/darrenmoura/budibase-datasource-jira-cloud-issues).